### PR TITLE
Fix Navbar Link

### DIFF
--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -34,7 +34,7 @@ const Navbar = () => {
         {lightbulb.enabled ? (
           <li className="nav__list-item">
             <a
-              href="#skills"
+              href="#lightbulb"
               onClick={toggleNavList}
               className="link link--nav"
             >


### PR DESCRIPTION
In the Navbar component, there seems to be an error with the link for the lightbulb entry, which instead takes the user to the skills section. This is not intended behavior, as clicking on the lightbulb button should take you to the lightbulb section. This has since been fixed.